### PR TITLE
use run_id alias for sampling time fields

### DIFF
--- a/tests/test_corrections.py
+++ b/tests/test_corrections.py
@@ -234,7 +234,7 @@ class TestCorrections(unittest.TestCase):
             st.builds(
                 SomeSampledCorrection,
                 version=st.just("ONLINE"),
-                time=datetimes,
+                run_id=datetimes,
                 value=floats,
             ),
             min_size=3,


### PR DESCRIPTION
Since hypothesis uses the alias when constructing samples with `st.builds`, we need to use the alias when overriding strategies for the time field.