### PR TITLE
Dont load api and github datasources by default

### DIFF
--- a/xedocs/databases/api.py
+++ b/xedocs/databases/api.py
@@ -17,7 +17,7 @@ class ApiSettings(BaseSettings):
         env_prefix = "XEDOCS_API_"
         env_file = XEDOCS_API_ENV
 
-    PRIORITY: int = 2
+    PRIORITY: int = -1
     URL_TEMPLATE: str = "{base_url}/{version}/{database}/{name}"
     BASE_URL: str = "https://api.xedocs.yossisprojects.com"
     VERSION: str = "v1"

--- a/xedocs/databases/github.py
+++ b/xedocs/databases/github.py
@@ -42,7 +42,7 @@ class GithubSettings(BaseSettings):
         env_prefix = "XEDOCS_GITHUB_"
         env_file = XEDOCS_GITHUB_ENV
 
-    PRIORITY: int = 3
+    PRIORITY: int = -1
     ORG: str = "XENONnT"
     REPO: str = "xedocs-data"
     URL_TEMPLATE: str = "github://{org}:{repo}@/{database}/{category}/{name}/*.json"


### PR DESCRIPTION
Since github and API may not be accessible from dali worker nodes, lets load them only if explicitly requested by user with e.g:

`XEDOCS_GITHUB_PRIORITY=3`
`XEDOCS_API_PRIORITY=2`