### PR TITLE
call filter_kwargs with correct arg order

### DIFF
--- a/xedocs/_straxen_plugin.py
+++ b/xedocs/_straxen_plugin.py
@@ -25,7 +25,7 @@ def xedocs_protocol(
 
     accessor = getattr(schema, db)
 
-    kwargs = straxen.filter_kwargs(labels, accessor.find_docs)
+    kwargs = straxen.filter_kwargs(accessor.find_docs, labels)
     
     if isinstance(sort, (str,list)):
         kwargs["sort"] = sort


### PR DESCRIPTION
bug in the URLConfig protocol, called filter_kwargs with reversed order of arguments