### PR TITLE
Remove superfluous time index definitions

### DIFF
--- a/xedocs/_settings.py
+++ b/xedocs/_settings.py
@@ -134,8 +134,8 @@ class Settings(BaseSettings):
 
     def run_id_to_interval(self, run_id):
         doc = self.run_doc(run_id)
-        start = self.clock.normalize_tz(doc["start"])
-        end = self.clock.normalize_tz(doc["end"])
+        start = self.clock.normalize_tz(doc["start"]+pd.Timedelta("1s"))
+        end = self.clock.normalize_tz(doc["end"]-pd.Timedelta("1s"))
         return start, end
 
     def extract_time(self, kwargs):

--- a/xedocs/schemas/corrections/base_references.py
+++ b/xedocs/schemas/corrections/base_references.py
@@ -90,6 +90,5 @@ class BaseMap(BaseResourceReference):
     _ALIAS = ""
 
     algorithm: Literal["cnn", "gcn", "mlp"] = rframe.Index()
-    time: rframe.Interval[datetime.datetime] = rframe.IntervalIndex()
 
     value: str

--- a/xedocs/schemas/corrections/bayes_model.py
+++ b/xedocs/schemas/corrections/bayes_model.py
@@ -12,5 +12,4 @@ class NaiveBayesClassifier(BaseResourceReference):
     _ALIAS = "bayes_models"
     fmt = "binary"
 
-    time: rframe.Interval[datetime.datetime] = rframe.IntervalIndex()
     value: str

--- a/xedocs/schemas/corrections/position_reconstruction.py
+++ b/xedocs/schemas/corrections/position_reconstruction.py
@@ -24,6 +24,5 @@ class PosRecModel(BaseResourceReference):
     fmt = "binary"
 
     kind: Literal["cnn", "gcn", "mlp"] = rframe.Index()
-    time: rframe.Interval[datetime.datetime] = rframe.IntervalIndex()
 
     value: str


### PR DESCRIPTION
Some corrections were overriding the already defined time index, this removed the time validator function in those corrections resulting in no auto conversion from run_id to time.