### PR TITLE
Adding s1_cnn as an option for the position reconstruction

### DIFF
--- a/xedocs/schemas/corrections/position_reconstruction.py
+++ b/xedocs/schemas/corrections/position_reconstruction.py
@@ -23,6 +23,7 @@ class PosRecModel(BaseResourceReference):
     _ALIAS = "posrec_models"
     fmt = "binary"
 
-    kind: Literal["cnn", "gcn", "mlp"] = rframe.Index()
+    kind: Literal["cnn", "gcn", "mlp", "s1_cnn"] = rframe.Index()
 
     value: str
+    


### PR DESCRIPTION
Matteo is working on adding an S1 cnn position reconstruction algorithm to straxen. I just modified the pos_rec schema to allow for an index of the name s1_cnn.