### PR TITLE
add default datasource

### DIFF
--- a/xedocs/xedocs.py
+++ b/xedocs/xedocs.py
@@ -22,7 +22,9 @@ __all__ = [
     "list_schemas",
     "all_schemas",
     "schemas_by_category",
+    "default_datasource_for",
     "find_schema",
+    "get_api_client",
     "download_db",
 ]
 


### PR DESCRIPTION
The function for fetching a default datasource was not being registered to the xedocs namespaces. This PR fixes that so that functions that rely on the existence of a default datasource will work.