### PR TITLE
Add photoionization schema

### DIFF
--- a/xedocs/schemas/corrections/__init__.py
+++ b/xedocs/schemas/corrections/__init__.py
@@ -21,4 +21,4 @@ from .avg_se_gain import *
 from .bayes_model import *
 from .som_network import *
 from .hotspot_veto_cut import *
-from .photoionizations import *
+from .photoionization_strength import *

--- a/xedocs/schemas/corrections/__init__.py
+++ b/xedocs/schemas/corrections/__init__.py
@@ -21,3 +21,4 @@ from .avg_se_gain import *
 from .bayes_model import *
 from .som_network import *
 from .hotspot_veto_cut import *
+from .photoionizations import *

--- a/xedocs/schemas/corrections/photoionization_strength.py
+++ b/xedocs/schemas/corrections/photoionization_strength.py
@@ -1,0 +1,11 @@
+"""
+# Photoionization strengths
+https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt_sr1:photoionization_origin
+"""
+
+from .base_corrections import TimeSampledCorrection
+
+
+class PhotoionizationStrength(TimeSampledCorrection):
+    _ALIAS = "photoionization_strength"
+    value: float

--- a/xedocs/schemas/corrections/photoionization_strength.py
+++ b/xedocs/schemas/corrections/photoionization_strength.py
@@ -7,5 +7,5 @@ from .base_corrections import TimeSampledCorrection
 
 
 class PhotoionizationStrength(TimeSampledCorrection):
-    _ALIAS = "photoionization_strength"
+    _ALIAS = "photoionization_strengths"
     value: float


### PR DESCRIPTION
As @xzh19980906 will show [today](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:zihao:sr1_s2aft_photonionization_correction) the time-dependent corrections can be build using linear correlation with photoionization strength. I propose we store these values too in the corrections, and use this to make all SR1 relative/absolute LY/QY corrections.