### PR TITLE
Test for modifications to ONLINE permisions

### DIFF
--- a/xedocs/xedocs.py
+++ b/xedocs/xedocs.py
@@ -79,9 +79,9 @@ def find_one(schema, datasource=None, **labels):
 
 def insert_docs(schema: str, docs: Union[list, dict, pd.DataFrame], datasource=None, dry=False):
     # Currently stuck on how to deal with instances of schemas
-    if datasource == 'development_db': # switch to straxen_db
+    if datasource == 'straxen_db': # switch to straxen_db
         mongo_username = MongoDB().username
-        if mongo_username == 'nt_analysis':
+        if mongo_username == 'corrections_expert':
             # If statements only trigger
             target_version = "ONLINE"
             # Note to self: This is done in a very dumb way, fix later

--- a/xedocs/xedocs.py
+++ b/xedocs/xedocs.py
@@ -82,6 +82,7 @@ def insert_docs(schema: str, docs: Union[list, dict, pd.DataFrame], datasource=N
     if datasource == 'development_db': # switch to straxen_db
         mongo_username = MongoDB().username
         if mongo_username == 'nt_analysis':
+            # If statements only trigger
             target_version = "ONLINE"
             # Note to self: This is done in a very dumb way, fix later
             ONLINE_check = True
@@ -102,6 +103,9 @@ def insert_docs(schema: str, docs: Union[list, dict, pd.DataFrame], datasource=N
                         # This assumes the last choice is a schema, if not other things will yield errors?
                         # This is kinda sloppy...
                         ONLINE_check = all(item.version == target_version for item in docs)
+                elif hasattr(docs, 'version'):
+                    if docs.version != target_version: # if version isnt ONLINE
+                        ONLINE_check = False
                 else:
                     ONLINE_check = all(item.version == target_version for item in docs)
 


### PR DESCRIPTION
The purpose of this pull request is to only allow a particular user to insert ONLINE corrections and no others to protect the integrity of the database. This is not a full proof way of preventing this but it should at least prevent people from changing the database accidentally. We should update everyone to a new version of xedocs before giving out the new username and password

