### PR TITLE
Minor change of error message for unavailable docs

### DIFF
--- a/xedocs/_straxen_plugin.py
+++ b/xedocs/_straxen_plugin.py
@@ -50,7 +50,10 @@ def xedocs_protocol(
     docs = accessor.find_docs(**kwargs)
 
     if not docs:
-        raise KeyError(f"No matching documents found for {name}.")
+        raise KeyError(
+            f"No matching documents found for {name}. "
+            "It is possible that there is no corresponding data."
+        )
 
     if isinstance(sort, str):
         docs = sorted(docs, key=lambda x: getattr(x, sort))


### PR DESCRIPTION
Before this, when seeing `raise KeyError(f"No matching documents found for {name}.")`, people will think that the schema is missing. After this PR, I hope the user gets the feeling that it is not the schema that is missing but the data(docs) are missing. The availability of schema is checked at https://github.com/XENONnT/xedocs/blob/cdf7fc922b5cc79dd833903034348fa60457b27f/xedocs/_straxen_plugin.py#L40