### PR TITLE
change db accessing format (notebook)

### DIFF
--- a/notebooks/Accessing_and_inserting_data.ipynb
+++ b/notebooks/Accessing_and_inserting_data.ipynb
@@ -85,7 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "xd_db_dev = xd.development_db.utilix"
+    "xd_db_dev = xd.development_db()"
    ]
   },
   {
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "xd_db_stx = xd.straxen_db.utilix"
+    "xd_db_stx = xd.straxen_db()"
    ]
   },
   {


### PR DESCRIPTION
changed the notebook corresponding how to access data based later changes to xedocs. Notebook should now be reproducable with the current version of xedocs