### PR TITLE
Add extra mongodb config when constructing client

### DIFF
--- a/xedocs/data_locations/mongodb.py
+++ b/xedocs/data_locations/mongodb.py
@@ -5,9 +5,9 @@ from rframe import DataAccessor
 
 
 def xenon_config_source(settings: BaseSettings) -> Dict[str, Any]:
-    from xedocs import settings
+    from xedocs import settings as xenon_settings
 
-    cfg = settings.xenon_config.RunDB
+    cfg = xenon_settings.xenon_config.RunDB
     data = {}
     if cfg.xent_url:
         data['host'] = cfg.xent_url
@@ -17,6 +17,14 @@ def xenon_config_source(settings: BaseSettings) -> Dict[str, Any]:
         data['password'] = cfg.xent_password
     if cfg.xent_database:
         data['auth_db'] = cfg.xent_database
+    if cfg.max_pool_size:
+        data['max_pool_size'] = cfg.max_pool_size
+    if cfg.socket_timeout:
+        data['socket_timeout'] = cfg.socket_timeout
+    if cfg.connect_timeout:
+        data['connect_timeout'] = cfg.connect_timeout
+    if cfg.read_preference:
+        data['read_preference'] = cfg.read_preference
     return data
 
 
@@ -50,17 +58,26 @@ class MongoDB(BaseSettings):
     host: str = "localhost"
     connection_uri: str = None
 
+    max_pool_size: int = 100
+    socket_timeout: int = 60000
+    connect_timeout: int = 60000
+    read_preference: str = "secondaryPreferred"
+
     @property
     def client(self):
         if self.connection_uri is None:
-            self.connection_uri = f"mongodb://{self.username}:{self.password}@{self.host}?authSource={self.auth_db}&readPreference=secondary"
+            self.connection_uri = f"mongodb://{self.username}:{self.password}@{self.host}?authSource={self.auth_db}"
         if self.connection_uri not in self.CLIENT_CACHE:
             self.CLIENT_CACHE[self.connection_uri] = self.make_client(self.connection_uri)
         return self.CLIENT_CACHE[self.connection_uri]
 
     def make_client(self, connection_uri):
         import pymongo
-        return pymongo.MongoClient(connection_uri)
+        return pymongo.MongoClient(connection_uri, 
+                                   maxPoolSize=self.max_pool_size,
+                                   socketTimeoutMS=self.socket_timeout,
+                                   connectTimeoutMS=self.connect_timeout,
+                                   readPreference=self.read_preference)
 
     @classmethod
     def from_utilix(cls, **kwargs):

--- a/xedocs/xenon_config.py
+++ b/xedocs/xenon_config.py
@@ -53,6 +53,7 @@ class RunDBConfig(BaseModel):
     max_pool_size: int = 100
     socket_timeout: int = 60000
     connect_timeout: int = 60000
+    read_preference: str = "secondaryPreferred"
 
 
 class StraxenConfig(BaseModel):


### PR DESCRIPTION
This PR modifies the MongoDB client to support the following configs with defaults:
```python
    max_pool_size: int = 100
    socket_timeout: int = 60000
    connect_timeout: int = 60000
    read_preference: str = "secondaryPreferred"

```

This can be useful eg when submitting massive numbers of jobs to a cluster, each with many threads. you may want to limit the number of connections each process in each job can open to a very small number (the default it 100+2 connections  per process). You may see a small performance hit due to IO delays as queries will need to wait for their turn at an open socket connection but at least you wont overwhelm the mongo server with billions of simultaneous connections.