### PR TITLE
Merge AB and CD partitioning into avg SEG schema

### DIFF
--- a/xedocs/schemas/corrections/implementations/avg_se_gain.py
+++ b/xedocs/schemas/corrections/implementations/avg_se_gain.py
@@ -1,10 +1,19 @@
 """
+This schema incorporates two iece of inforamtion for the SEG & EE correciont. Namely the average single electron gain
+and the definition of the AB and CD partitions
+
 Correction: Average single electron gain
 Affects: Corrected areas
 
 Average of the single electron corrections. This correction my also have two partitions as this average is a temporal average not a spatial one.
 
-wiki:
+Correction: Region linear and circular for AB/CD partitions
+Affects: Corrected areas
+
+Two distinct patterns of evolution of single electron corrections between A+B and C+D. Distinguish thanks to linear and circular regions
+SR0 wiki: https://xe1t-wiki.lngs.infn.it/doku.php?id=jlong:sr0_2_region_se_correction
+SR1 wiki: https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:noahhood:corrections:se_gain_ee_final
+
 """
 
 import rframe
@@ -16,5 +25,7 @@ from ...constants import PARTITION
 class AvgSingleElectronGain(TimeIntervalCorrection):
 
     _ALIAS = "avg_se_gains"
+    field: str = rframe.Index(max_length=80)
     partition: PARTITION = rframe.Index(default="all_tpc")
+    
     value: float

--- a/xedocs/schemas/corrections/implementations/avg_se_gain.py
+++ b/xedocs/schemas/corrections/implementations/avg_se_gain.py
@@ -1,5 +1,5 @@
 """
-This schema incorporates two iece of inforamtion for the SEG & EE correciont. Namely the average single electron gain
+This schema incorporates two piece of inforamtion for the SEG & EE correciont. Namely the average single electron gain
 and the definition of the AB and CD partitions
 
 Correction: Average single electron gain

--- a/xedocs/schemas/corrections/implementations/avg_se_gain.py
+++ b/xedocs/schemas/corrections/implementations/avg_se_gain.py
@@ -1,16 +1,16 @@
 """
-This schema incorporates two piece of inforamtion for the SEG & EE correciont. Namely the average single electron gain
-and the definition of the AB and CD partitions
+This schema incorporates two pieces of information for the SEG & EE correction. Namely the average single electron gain
+and the definition of the AB and CD partitions.
 
 Correction: Average single electron gain
 Affects: Corrected areas
 
-Average of the single electron corrections. This correction my also have two partitions as this average is a temporal average not a spatial one.
+Average of the single electron corrections. This correction may also have two partitions as this average is a temporal average and not a spatial one.
 
 Correction: Region linear and circular for AB/CD partitions
 Affects: Corrected areas
 
-Two distinct patterns of evolution of single electron corrections between A+B and C+D. Distinguish thanks to linear and circular regions
+Two distinct patterns of evolution of single electron corrections between A+B and C+D. Distinguished thanks to linear and circular regions.
 SR0 wiki: https://xe1t-wiki.lngs.infn.it/doku.php?id=jlong:sr0_2_region_se_correction
 SR1 wiki: https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:noahhood:corrections:se_gain_ee_final
 


### PR DESCRIPTION
Merge SEG TPC partitioning into avg_se_gain schema as suggested by @LuisSanchez25.
The selection of the avg SEG or the partitioning parameters is based on `field` index

![immagine](https://github.com/XENONnT/xedocs/assets/38431109/57e2d3e0-46bf-420b-83d3-1146d9795395)
![immagine](https://github.com/XENONnT/xedocs/assets/38431109/fbe2bdc5-2654-4d48-93a7-b70ba5b0bb0d)
![immagine](https://github.com/XENONnT/xedocs/assets/38431109/c586e30c-d520-4236-b0d0-8a9e0857c83c)
