### PR TITLE
Update to 0.2.27 test

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.26
+current_version = 0.2.27
 commit = True
 tag = True
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,19 @@
 History
 =======
 
+0.2.27 (2024-04-29)
+------------------
+* Update README.rst by @kdund in https://github.com/XENONnT/xedocs/pull/116
+* Reorganize corrections by @LuisSanchez25 in https://github.com/XENONnT/xedocs/pull/110
+* change db accessing format (notebook) by @LuisSanchez25 in https://github.com/XENONnT/xedocs/pull/117
+* Test for modifications to ONLINE permisions by @LuisSanchez25 in https://github.com/XENONnT/xedocs/pull/113
+* from TimeSampledCorrection to TimeIntervalCorrection by @GiovanniVolta in https://github.com/XENONnT/xedocs/pull/119
+* Add extra mongodb config when constructing client by @jmosbacher in https://github.com/XENONnT/xedocs/pull/118
+* schema for SEG partitions by @GiovanniVolta in https://github.com/XENONnT/xedocs/pull/120
+* Bump supercharge/mongodb-github-action from 1.9.0 to 1.10.0 by @dependabot in https://github.com/XENONnT/xedocs/pull/104
+
+**Full Changelog**: https://github.com/XENONnT/xedocs/compare/v0.2.26...v0.2.27
+
 0.2.26 (2024-02-15)
 ------------------
 * Minor change of error message for unavailable docs by @dachengx in https://github.com/XENONnT/xedocs/pull/114

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "xedocs"
-version = "0.2.26"
+version = "0.2.27"
 homepage = "https://github.com/XENONnT/xedocs"
 description = "Top-level package for xedocs."
 authors = ["Yossi Mosbacher <joe.mosbacher@gmail.com>"]

--- a/xedocs/__init__.py
+++ b/xedocs/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Yossi Mosbacher"""
 __email__ = "joe.mosbacher@gmail.com"
-__version__ = "0.2.26"
+__version__ = "0.2.27"
 
 
 import logging


### PR DESCRIPTION
Bump version from 0.2.26 to [0.2.27](https://github.com/XENONnT/xedocs/releases/tag/v0.2.27).
