### PR TITLE
Detector numbers

### DIFF
--- a/xedocs/schemas/detector_numbers.py
+++ b/xedocs/schemas/detector_numbers.py
@@ -14,6 +14,7 @@ class DetectorNumber(TimeIntervalCorrection):
 
     field: str = rframe.Index(max_length=80)
     partition: PARTITION = rframe.Index(default="all_tpc")
+    science_run: str = rframe.Index(max_length=80)
     definition: str=""
     value: float
     uncertainty: float

--- a/xedocs/schemas/detector_numbers.py
+++ b/xedocs/schemas/detector_numbers.py
@@ -1,11 +1,10 @@
 import rframe
 import datetime
 
-from .base_schemas import VersionedXeDoc
+from corrections.base_corrections import TimeIntervalCorrection
 from .constants import PARTITION
 
-
-class DetectorNumber(VersionedXeDoc):
+class DetectorNumber(TimeIntervalCorrection):
     """Detector parameters
     A collection of non-time dependent detector
     values.

--- a/xedocs/schemas/detector_numbers.py
+++ b/xedocs/schemas/detector_numbers.py
@@ -14,6 +14,7 @@ class DetectorNumber(TimeIntervalCorrection):
 
     field: str = rframe.Index(max_length=80)
     partition: PARTITION = rframe.Index(default="all_tpc")
+    definition: str=""
     value: float
     uncertainty: float
     reference: str = ""

--- a/xedocs/schemas/detector_numbers.py
+++ b/xedocs/schemas/detector_numbers.py
@@ -1,7 +1,7 @@
 import rframe
 import datetime
 
-from corrections.base_corrections import TimeIntervalCorrection
+from .corrections.base_corrections import TimeIntervalCorrection
 from .constants import PARTITION
 
 class DetectorNumber(TimeIntervalCorrection):
@@ -14,10 +14,6 @@ class DetectorNumber(TimeIntervalCorrection):
 
     field: str = rframe.Index(max_length=80)
     partition: PARTITION = rframe.Index(default="all_tpc")
-
     value: float
     uncertainty: float
-    definition: str
     reference: str = ""
-    date: datetime.datetime
-    comments: str = ""


### PR DESCRIPTION
Changing DetectorNumbers schema to kind `TimeIntervalCorrections` to move detector_numbers, especially g1 and g2 to `xedocs`. 

