### PR TITLE
add flow model to pos_rec

### DIFF
--- a/xedocs/schemas/corrections/implementations/position_reconstruction.py
+++ b/xedocs/schemas/corrections/implementations/position_reconstruction.py
@@ -8,6 +8,7 @@ See description in the Team C overview page [here](https://xe1t-wiki.lngs.infn.i
 
 Mostly following the "OFF PMTs" list [here](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:dsg:pmt:gains:pmtsoff)
 
+More information on the flow model can be found [here](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:svetter:conditional_norm_flow_posrec_principle)
 
 """
 

--- a/xedocs/schemas/corrections/implementations/position_reconstruction.py
+++ b/xedocs/schemas/corrections/implementations/position_reconstruction.py
@@ -23,7 +23,7 @@ class PosRecModel(BaseResourceReference):
     _ALIAS = "posrec_models"
     fmt = "binary"
 
-    kind: Literal["cnn", "gcn", "mlp", "s1_cnn"] = rframe.Index()
+    kind: Literal["cnn", "gcn", "mlp", "s1_cnn", "flow"] = rframe.Index()
 
     value: str
     


### PR DESCRIPTION
This pull request is simply to add a field called "flow" to the options regarding the position reconstruction algorithms. For more information about this new model see the following [note](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:svetter:conditional_norm_flow_posrec_principle).