### PR TITLE
bump version v0.2.30

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.29
+current_version = 0.2.30
 commit = True
 tag = True
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,7 +2,7 @@
 History
 =======
 
-0.2.31 (2024-09-06)
+0.2.30 (2024-09-06)
 ------------------
 * Add a new correction test_corrections to test inserting corrections into the xedocs database before moving to ONLINE corrections by @LuisSanchez25
 * Add a new kind of machine learning algorithm for position reconstruction by @LuisSanchez25

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.2.31 (2024-09-06)
+------------------
+* Add a new correction test_corrections to test inserting corrections into the xedocs database before moving to ONLINE corrections by @LuisSanchez25
+* Add a new kind of machine learning algorithm for position reconstruction by @LuisSanchez25
+
 0.2.29 (2024-06-24)
 ------------------
 * Xedocs version bump to accomdate rframe version bump https://github.com/XENONnT/rframe/pull/62

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "xedocs"
-version = "0.2.29"
+version = "0.2.30"
 homepage = "https://github.com/XENONnT/xedocs"
 description = "Top-level package for xedocs."
 authors = ["Yossi Mosbacher <joe.mosbacher@gmail.com>"]

--- a/xedocs/__init__.py
+++ b/xedocs/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Yossi Mosbacher"""
 __email__ = "joe.mosbacher@gmail.com"
-__version__ = "0.2.29"
+__version__ = "0.2.30"
 
 
 import logging


### PR DESCRIPTION
We need a new version release to update the types of machine learning that xedocs will accept for position reconstruction. This is needed to prevent tests in the corrections repo from failing when adding this new correction to the database.