### PR TITLE
Detector Operations Log

### DIFF
--- a/xedocs/schemas/operations_reports/__init__.py
+++ b/xedocs/schemas/operations_reports/__init__.py
@@ -2,3 +2,4 @@ from .hotspot import HotspotReport
 from .anode_ramp import AnodeRampReport
 from .anode_washing import AnodeWashingReport
 from .abnormal_rates import AbnormalDAQRate
+from .detector_operations import DetectorOperations

--- a/xedocs/schemas/operations_reports/detector_operations.py
+++ b/xedocs/schemas/operations_reports/detector_operations.py
@@ -1,0 +1,11 @@
+from typing import Literal
+from .base_report import BaseOperationsReport
+
+class DetectorOperations(BaseOperationsReport):
+    """ Detector Operations Reports """
+
+    _ALIAS="detector_operations"
+
+    system:Literal["CRY", "PUR", "LXePUR", "RSX", "RSX_2", "DST", "RAD", "DAQ"]
+    subject: str
+    


### PR DESCRIPTION
Provides a new schema that RCs can use through the xedocs website to log general operations on the detector. [Requested by ACs and RC](https://xenonnt.slack.com/archives/C016UJZ090B/p1724770994083319). No numerical values can be input and no interpolation is expected. This is a general sort of 'eLog', that can now be accessible for everyone through xedocs.