### PR TITLE
`baseline_samples_nv` should be int

### DIFF
--- a/xedocs/schemas/corrections/implementations/baseline_samples_nv.py
+++ b/xedocs/schemas/corrections/implementations/baseline_samples_nv.py
@@ -14,4 +14,4 @@ from ..base_corrections import TimeSampledCorrection
 class BaselineSamplesNV(TimeSampledCorrection):
 
     _ALIAS = "baseline_samples_nv"
-    value: float
+    value: int


### PR DESCRIPTION
Otherwise when `export NUMBA_DISABLE_JIT=1` you will see an error:

```
Exception during processing, closing savers and reraising
Traceback (most recent call last):
  File "/cvmfs/xenon.opensciencegrid.org/releases/nT/el9.2024.09.1/anaconda/envs/XENONnT_el9.2024.09.1/lib/python3.9/pdb.py", line 1726, in main
    pdb._runscript(mainpyfile)
  File "/cvmfs/xenon.opensciencegrid.org/releases/nT/el9.2024.09.1/anaconda/envs/XENONnT_el9.2024.09.1/lib/python3.9/pdb.py", line 1586, in _runscript
    self.run(statement)
  File "/cvmfs/xenon.opensciencegrid.org/releases/nT/el9.2024.09.1/anaconda/envs/XENONnT_el9.2024.09.1/lib/python3.9/bdb.py", line 580, in run
    exec(cmd, globals, locals)
  File "<string>", line 1, in <module>
  File "/home/xudc/analysiscode/straxen_debug/python_scripts/process_memory_usage.py", line 1, in <module>
    import sys
  File "/cvmfs/xenon.opensciencegrid.org/releases/nT/el9.2024.09.1/anaconda/envs/XENONnT_el9.2024.09.1/lib/python3.9/site-packages/memory_profiler.py", line 379, in memory_usage
    returned = f(*args, **kw)
  File "/home/xudc/outsource/outsource/workflow/process.py", line 110, in main
    process(st, run_id, data_type, chunks)
  File "/home/xudc/analysiscode/straxen_debug/python_scripts/process_memory_usage.py", line 46, in wrapped
    process(st, run_id, data_type, chunks)
  File "/home/xudc/outsource/outsource/workflow/process.py", line 31, in process
    st.make(
  File "/home/xudc/strax/strax/context.py", line 1756, in make
    for _ in self.get_iter(
  File "/home/xudc/strax/strax/context.py", line 1647, in get_iter
    generator.throw(e)
  File "/home/xudc/strax/strax/context.py", line 1614, in get_iter
    for n_chunks, result in enumerate(strax.continuity_check(generator), 1):
  File "/home/xudc/strax/strax/chunk.py", line 363, in continuity_check
    for chunk in chunk_iter:
  File "/home/xudc/strax/strax/processors/single_thread.py", line 63, in iter
    yield from final_generator
  File "/home/xudc/strax/strax/processors/post_office.py", line 204, in _read
    result = self._fetch_new(topic)
  File "/home/xudc/strax/strax/processors/post_office.py", line 247, in _fetch_new
    msg = next(self._producers[topic])
  File "/home/xudc/strax/strax/plugins/plugin.py", line 434, in iter
    self._fetch_chunk(d, iters)
  File "/home/xudc/strax/strax/plugins/plugin.py", line 403, in _fetch_chunk
    [self.input_buffer[d], next(iters[d])], self.allow_superrun
  File "/home/xudc/strax/strax/processors/post_office.py", line 204, in _read
    result = self._fetch_new(topic)
  File "/home/xudc/strax/strax/processors/post_office.py", line 247, in _fetch_new
    msg = next(self._producers[topic])
  File "/home/xudc/strax/strax/plugins/plugin.py", line 531, in iter
    yield from self._iter_compute(chunk_i=chunk_i, **inputs_merged)
  File "/home/xudc/strax/strax/plugins/plugin.py", line 558, in _iter_compute
    yield self.do_compute(chunk_i=chunk_i, **inputs_merged)
  File "/home/xudc/strax/strax/plugins/plugin.py", line 667, in do_compute
    result = self.compute(**kwargs)
  File "/home/xudc/straxen/straxen/plugins/records_nv/records_nv.py", line 78, in compute
    strax.baseline(r, baseline_samples=self.baseline_samples, flip=True)
  File "/home/xudc/strax/strax/processing/pulse_processing.py", line 51, in baseline
    w = d["data"][:baseline_samples]
TypeError: slice indices must be integers or None or have an __index__ method
Uncaught exception. Entering post mortem debugging
Running 'cont' or 'step' will restart the program
```

Because `baseline_samples_nv` should be int.