### PR TITLE
adding cnf

### DIFF
--- a/xedocs/schemas/corrections/base_references.py
+++ b/xedocs/schemas/corrections/base_references.py
@@ -93,7 +93,7 @@ class BaseMap(BaseResourceReference):
                         'dill.gz','dill', 'npy_pickle',
                         'binary', 'text', 'txt', 'csv']
 
-    algorithm: Literal["cnn", "gcn", "mlp"] = rframe.Index()
+    algorithm: Literal["cnn", "gcn", "mlp", "cnf"] = rframe.Index()
 
     value: str
 

--- a/xedocs/schemas/corrections/implementations/position_reconstruction.py
+++ b/xedocs/schemas/corrections/implementations/position_reconstruction.py
@@ -24,7 +24,7 @@ class PosRecModel(BaseResourceReference):
     _ALIAS = "posrec_models"
     fmt = "binary"
 
-    kind: Literal["cnn", "gcn", "mlp", "s1_cnn", "flow"] = rframe.Index()
+    kind: Literal["cnn", "gcn", "mlp", "s1_cnn", "flow", "cnf"] = rframe.Index()
 
     value: str
     


### PR DESCRIPTION
Since in straxen, we now have [cnf as the new default pos_rec algo](https://github.com/XENONnT/straxen/blob/4d2c89e906e3bcd46c9702ff6700675ddf455bf3/straxen/plugins/defaults.py#L3), we have updated the list of algorithms here in xedocs