### PR TITLE
Remove `flow` from `PosRecModel`

### DIFF
--- a/xedocs/schemas/corrections/implementations/position_reconstruction.py
+++ b/xedocs/schemas/corrections/implementations/position_reconstruction.py
@@ -24,7 +24,6 @@ class PosRecModel(BaseResourceReference):
     _ALIAS = "posrec_models"
     fmt = "binary"
 
-    kind: Literal["cnn", "gcn", "mlp", "s1_cnn", "flow", "cnf"] = rframe.Index()
+    kind: Literal["cnn", "gcn", "mlp", "cnf", "s1_cnn"] = rframe.Index()
 
     value: str
-    


### PR DESCRIPTION
because we use `cnf`

Related to https://github.com/XENONnT/xedocs/pull/139/files#r1894815602