### PR TITLE
Remove `map` and `file` method to centralize the protocols in straxen

### DIFF
--- a/xedocs/schemas/corrections/base_references.py
+++ b/xedocs/schemas/corrections/base_references.py
@@ -111,9 +111,3 @@ class BaseMap(BaseResourceReference):
         import utilix
         downloader = utilix.mongo_storage.MongoDownloader()
         return downloader.download_single(self.value)
-
-    @property
-    def file(self):
-        import straxen
-        file = straxen.get_resource(self.value, fmt=self.fmt)
-        return file

--- a/xedocs/schemas/corrections/base_references.py
+++ b/xedocs/schemas/corrections/base_references.py
@@ -117,8 +117,3 @@ class BaseMap(BaseResourceReference):
         import straxen
         file = straxen.get_resource(self.value, fmt=self.fmt)
         return file
-
-    @property
-    def map(self):
-        import straxen
-        return straxen.InterpolatingMap(self.file)


### PR DESCRIPTION
This is related to a discussion https://xenonnt.slack.com/archives/C016UJZ090B/p1736531931224399?thread_ts=1736525098.620719&cid=C016UJZ090B.

We want to only extract the filename without opening it. The way to do this is to stop the URL pipeline before `resource` protocol and other protocols that open the file.

`map` method is something that is not easily controlled because it is outside straxen, so maybe it is better to delete it.