### PR TITLE
Force to use file protocol in fsspec

### DIFF
--- a/xedocs/dispatchers.py
+++ b/xedocs/dispatchers.py
@@ -54,8 +54,8 @@ def read_csv_files(path, **kwargs) -> List[dict]:
     docs =[]
     
     with fsspec.open_files(path, **kwargs) as fs:
-         kwargs = rframe.utils.filter_kwargs(pd.read_csv, kwargs)
-         for f in fs:
+        kwargs = rframe.utils.filter_kwargs(pd.read_csv, kwargs)
+        for f in fs:
             ds = pd.read_csv(f, **kwargs).to_dict(orient='records')
             docs.extend(ds)
     return docs

--- a/xedocs/utils.py
+++ b/xedocs/utils.py
@@ -134,8 +134,9 @@ class LazyFileAccessor(DataAccessor):
     def iter_path_records(self, ignore_paths=(), **labels):
         for path in self.urlpaths:
             glob_patttern = self.format_to_glob(path)
-            fs, _, fpaths = fsspec.get_fs_token_paths(glob_patttern,
-                                                   storage_options=self.storage_options)
+            fs, _, fpaths = fsspec.get_fs_token_paths(glob_patttern, storage_options=self.storage_options)
+            # force the protocol to be file
+            fs.protocol = "file"
             pattern = path.replace(f"{fs.protocol}://", "")
             pattern = parse.compile(self.glob_to_format(pattern))
             loaded = set(ignore_paths)


### PR DESCRIPTION
To be compatible with old format fsspec before v2023.10.0

fsspec newer than that will return `fs.protocol = ("local", "file")` and confuse the dispatches functions like `read_json_files` https://github.com/XENONnT/xedocs/blob/008b018342f9d7cf6adc8e4e9b18f8f66b939c9a/xedocs/dispatchers.py#L65.