### PR TITLE
Fix iter path records

### DIFF
--- a/xedocs/utils.py
+++ b/xedocs/utils.py
@@ -136,18 +136,17 @@ class LazyFileAccessor(DataAccessor):
             glob_patttern = self.format_to_glob(path)
             fs, _, fpaths = fsspec.get_fs_token_paths(glob_patttern, storage_options=self.storage_options)
 
-            # Ensure fs.protocol is set, if not set a default protocol (e.g., 'file')
-            original_protocol1 = fs.protocol if fs.protocol else 'file'
-        
-            # Ensure only one protocol is selected, if it's a tuple, choose the first one
-            if isinstance(original_protocol1, tuple):
-                original_protocol = original_protocol1[0]
-    
+            # Always define original_protocol
+            original_protocol = fs.protocol if fs.protocol else 'file'
+            if isinstance(original_protocol, tuple):
+                original_protocol = original_protocol[0]
+            else:
+                original_protocol = original_protocol
+
             # Debug prints
             print(f"\n[DEBUG]")
             print(f"Processing path: {path}")
             print(f"fs.protocol: {fs.protocol}")
-            print(f"Original protocol1: {original_protocol1}")
             print(f"Original protocol: {original_protocol}")
             print(f"Glob pattern: {glob_patttern}")
             print(f"File paths: {fpaths}")

--- a/xedocs/utils.py
+++ b/xedocs/utils.py
@@ -135,20 +135,31 @@ class LazyFileAccessor(DataAccessor):
         for path in self.urlpaths:
             glob_patttern = self.format_to_glob(path)
             fs, _, fpaths = fsspec.get_fs_token_paths(glob_patttern, storage_options=self.storage_options)
-            # force the protocol to be file
-            fs.protocol = "file"
-            pattern = path.replace(f"{fs.protocol}://", "")
+    
+            original_protocol = fs.protocol  # don't overwrite it!
+    
+            # Debug prints
+            print(f"\n[DEBUG]")
+            print(f"Processing path: {path}")
+            print(f"Original protocol: {original_protocol}")
+            print(f"Glob pattern: {glob_patttern}")
+            print(f"File paths: {fpaths}")
+    
+            pattern = path.replace(f"{original_protocol}://", "")
             pattern = parse.compile(self.glob_to_format(pattern))
+    
+            # More debug prints
+            print(f"Parse pattern: {pattern}")
+    
             loaded = set(ignore_paths)
-
+    
             for fpath in fpaths:
                 if fpath in loaded:
                     continue
                 r = pattern.parse(fpath)
                 if r is None:
                     continue
-                for k,vs in labels.items():
-                    
+                for k, vs in labels.items():
                     if vs is None:
                         continue
                     if not isinstance(vs, list):
@@ -165,9 +176,10 @@ class LazyFileAccessor(DataAccessor):
                     if label not in vs:
                         break
                 else:
-                    records = read_files(fpath, protocol=fs.protocol, **fs.storage_options)
+                    records = read_files(fpath, protocol=original_protocol, **fs.storage_options)
                     yield fpath, records
                     self.loaded.add(fpath)
+
 
     def load_files(self, **labels):
         index_fields = list(self.schema.get_index_fields())

--- a/xedocs/utils.py
+++ b/xedocs/utils.py
@@ -135,12 +135,19 @@ class LazyFileAccessor(DataAccessor):
         for path in self.urlpaths:
             glob_patttern = self.format_to_glob(path)
             fs, _, fpaths = fsspec.get_fs_token_paths(glob_patttern, storage_options=self.storage_options)
-    
-            original_protocol = fs.protocol  # don't overwrite it!
+
+            # Ensure fs.protocol is set, if not set a default protocol (e.g., 'file')
+            original_protocol1 = fs.protocol if fs.protocol else 'file'
+        
+            # Ensure only one protocol is selected, if it's a tuple, choose the first one
+            if isinstance(original_protocol1, tuple):
+                original_protocol = original_protocol1[0]
     
             # Debug prints
             print(f"\n[DEBUG]")
             print(f"Processing path: {path}")
+            print(f"fs.protocol: {fs.protocol}")
+            print(f"Original protocol1: {original_protocol1}")
             print(f"Original protocol: {original_protocol}")
             print(f"Glob pattern: {glob_patttern}")
             print(f"File paths: {fpaths}")


### PR DESCRIPTION
This [PR](https://github.com/XENONnT/xedocs/pull/155) was meant ot fix the read from local folder but break the sync_db.py.
For instance running:
```
(
  source /cvmfs/xenon.opensciencegrid.org/releases/nT/el7.2025.03.1/setup.sh && \
  export XENON_CONFIG="/dali/lgrandi/giovo/SR2/xedocs/.xenon_config_corrections" && \
  export XEDOCS_SYNC_SCHEMAS=som_classifiers && \
  export XEDOCS_TARGET_DB=straxen_db && \
  export CONFIG_VERSION=v1 && \
  export XEDOCS_SYNC_LOG_FOLDER=./logs && \
  python3 sync_db.py
)
```

Before:
```
=== Syncing 'som_classifiers' ===
Grouping by: ['version']
unique: []
unique 2: {'version': []}
Label groups: []
v1
Filtered label combinations to process: []
```

Now:
=== Syncing 'som_classifiers' ===
```
Grouping by: ['version']
unique: ['ONLINE', 'v1', 'v2', 'v3', 'v4', 'v5']
unique 2: {'version': ['ONLINE', 'v1', 'v2', 'v3', 'v4', 'v5']}
Label groups: [('ONLINE',), ('v1',), ('v2',), ('v3',), ('v4',), ('v5',)]
v1
('ONLINE',)
('v1',)
('v2',)
('v3',)
('v4',)
('v5',)
Filtered label combinations to process: [('v1',)]
```

I ahve also check the follwing:
```
db = xedocs.straxen_db()
from_xedocs_db = db.som_classifiers.find_df(version='v1')
PATH_TO_REPO = '/dali/lgrandi/giovo/corrections/'
db_local = xedocs.local_folder(PATH_TO_REPO)
online = db_local.som_classifiers.find_df(version='v1')
```
and they are identical