### PR TITLE
Peak rec bias schema

### DIFF
--- a/xedocs/schemas/constants.py
+++ b/xedocs/schemas/constants.py
@@ -22,3 +22,5 @@ DIFFUSED_SOURCE = Literal["rn-220", "rn-222", "kr-83m", "ar-37",]
 DETECTOR = Literal["tpc", "neutron_veto", "muon_veto", "tpc_he"]
 
 PARTITION = Literal["all_tpc", "ab", "cd"]
+
+SIGNAL = Literal["s1", "s2"]

--- a/xedocs/schemas/corrections/implementations/__init__.py
+++ b/xedocs/schemas/corrections/implementations/__init__.py
@@ -26,3 +26,4 @@ from .z_bias import *
 from .cs2_aft_corrections import *
 from .se_gain_partition import *
 from .test_correction import *
+from .peak_reconstruction_bias import *

--- a/xedocs/schemas/corrections/implementations/peak_reconstruction_bias.py
+++ b/xedocs/schemas/corrections/implementations/peak_reconstruction_bias.py
@@ -7,11 +7,12 @@ https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xennont:peak_reconstruction_bia
 Description: We know that there are multiple effects that introduce a bias in the reconstructed area. We estimate this bias with simulations produced with fuse. We compare the raw area that is the input, with the reconstrcuted area. We observe that effects like thresholds, afterpulses (AP) and noise introduce an energy dependent bias of the order of 2-3%. We want to provide a correction for the S1 and S2 areas to take these effects into account. Note that photo-ionisation also induces a similar bias, but this topic is not addressed in this notes (for now). 
 
 """
+import rframe
 
-from ..base_references import BaseMap
+from ..base_references import BaseResourceReference
+from ...constants import SIGNAL
 
-
-class PeakReconstructionBias(BaseMap):
+class PeakReconstructionBias(BaseResourceReference):
     _ALIAS = "peak_reconstruction_bias"
     fmt = "json"
 

--- a/xedocs/schemas/corrections/implementations/peak_reconstruction_bias.py
+++ b/xedocs/schemas/corrections/implementations/peak_reconstruction_bias.py
@@ -1,0 +1,20 @@
+"""
+Peak Reconstruction Bias
+
+Atul Prajapati, Carlo Fuselli, Chiara Di Donato
+
+https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xennont:peak_reconstruction_bias_sr2
+Description: We know that there are multiple effects that introduce a bias in the reconstructed area. We estimate this bias with simulations produced with fuse. We compare the raw area that is the input, with the reconstrcuted area. We observe that effects like thresholds, afterpulses (AP) and noise introduce an energy dependent bias of the order of 2-3%. We want to provide a correction for the S1 and S2 areas to take these effects into account. Note that photo-ionisation also induces a similar bias, but this topic is not addressed in this notes (for now). 
+
+"""
+
+from ..base_references import BaseMap
+
+
+class PeakReconstructionBias(BaseMap):
+    _ALIAS = "peak_reconstruction_bias"
+    fmt = "json"
+
+    signal: SIGNAL = rframe.Index()
+
+    value: str


### PR DESCRIPTION
New scheme for peak reconstruction bias. See the [correction repo PR](https://github.com/XENONnT/corrections/pull/380) and private_nt file [here](https://github.com/XENONnT/straxen/pull/1592).